### PR TITLE
Ubuntu/RPi Cowrie Telnet+SSH deploy script

### DIFF
--- a/scripts/deploy_cowrie_telnet_ssh.sh
+++ b/scripts/deploy_cowrie_telnet_ssh.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# RPi/Ubuntu Cowrie Telnet+SSH 
+# Tested on Ubuntu 16.04 LTS Server and Raspbian Jessie Lite (March and July 2017 images)
+
+set -e
+set -x
+
+if [ $# -ne 2 ]
+    then
+        echo "Wrong number of arguments supplied."
+        echo "Usage: $0 <server_url> <deploy_key>."
+        exit 1
+fi
+
+apt-get update
+apt-get install -y python
+
+server_url=$1
+deploy_key=$2
+
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "cowrie"
+
+apt-get update
+apt-get -y install git python-pip python-virtualenv libssl-dev libffi-dev build-essential libpython-dev python2.7-minimal authbind supervisor
+
+pip install -U supervisor
+systemctl start supervisor || true
+
+sed -i 's/Port 22$/Port 2222/g' /etc/ssh/sshd_config
+service ssh restart
+useradd -d /home/cowrie -s /bin/bash -m cowrie -g users
+
+cd /opt
+git clone https://github.com/micheloosterhof/cowrie.git cowrie
+cd cowrie
+virtualenv cowrie-env
+source cowrie-env/bin/activate
+pip install -r requirements.txt
+
+cp cowrie.cfg.dist cowrie.cfg
+sed -i 's/hostname = svr04/hostname = ubuntu/g' cowrie.cfg
+sed -i 's/listen_endpoints = tcp:2222:interface=0.0.0.0/listen_endpoints = tcp:22:interface=0.0.0.0/g' cowrie.cfg
+sed -i 's/listen_endpoints = tcp:2223:interface=0.0.0.0/listen_endpoints = tcp:23:interface=0.0.0.0/g' cowrie.cfg
+sed -i 's/enabled = false/enabled = true/g' cowrie.cfg
+sed -i 's/version = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2/version = SSH-2.0-OpenSSH_6.7p1 Ubuntu-5ubuntu1.3/g' cowrie.cfg
+sed -i 's/#\[output_hpfeeds\]/[output_hpfeeds]/g' cowrie.cfg
+sed -i "s/#server = hpfeeds.mysite.org/server = $HPF_HOST/g" cowrie.cfg
+sed -i "s/#port = 10000/port = $HPF_PORT/g" cowrie.cfg
+sed -i "s/#identifier = abc123/identifier = $HPF_IDENT/g" cowrie.cfg
+sed -i "s/#secret = secret/secret = $HPF_SECRET/g" cowrie.cfg
+sed -i 's/#debug=false/debug=false/' cowrie.cfg
+
+chown -R cowrie:users /opt/cowrie/
+touch /etc/authbind/byport/22
+chown cowrie /etc/authbind/byport/22
+chmod 770 /etc/authbind/byport/22
+
+touch /etc/authbind/byport/23
+chown cowrie /etc/authbind/byport/23
+chmod 770 /etc/authbind/byport/23
+
+sed -i 's/AUTHBIND_ENABLED=no/AUTHBIND_ENABLED=yes/' bin/cowrie
+sed -i 's/DAEMONIZE=""/DAEMONIZE="-n"/' bin/cowrie
+
+# Config for supervisor
+cat > /etc/supervisor/conf.d/cowrie.conf <<EOF
+[program:cowrie]
+command=/opt/cowrie/bin/cowrie start
+directory=/opt/cowrie
+stdout_logfile=/opt/cowrie/log/cowrie.out
+stderr_logfile=/opt/cowrie/log/cowrie.err
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=cowrie
+EOF
+
+supervisorctl update


### PR DESCRIPTION
Works with the latest versions of Cowrie. Package additions work for both Ubuntu and RPi/Raspbian. Enables both the telnet and SSH honeypots. Both report attacks to MHN, with port number to determine attack protocol.